### PR TITLE
UI Tweaks

### DIFF
--- a/app/src/main/java/is/genki/bigredapp/android/DiningListFragment.java
+++ b/app/src/main/java/is/genki/bigredapp/android/DiningListFragment.java
@@ -358,7 +358,7 @@ public class DiningListFragment extends SwipeRefreshListFragment {
         } else if (isAlmostOpen) {
             textColor = res.getColor(R.color.almostOpenGreen);
         } else {
-            textColor = mTextColor;
+            textColor = res.getColor(R.color.closedColor);
         }
         hoursTextView.setTextColor(textColor);
     }

--- a/app/src/main/java/is/genki/bigredapp/android/DiningListFragment.java
+++ b/app/src/main/java/is/genki/bigredapp/android/DiningListFragment.java
@@ -86,6 +86,8 @@ public class DiningListFragment extends SwipeRefreshListFragment {
                 refreshContent();
             }
         });
+
+        getSwipeRefreshLayout().setColorSchemeResources(R.color.primary, R.color.primaryDark);
     }
 
     /**

--- a/app/src/main/res/layout/dining_list_row.xml
+++ b/app/src/main/res/layout/dining_list_row.xml
@@ -10,11 +10,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="name"
-        android:textSize="22sp"
-        android:paddingStart="8dp"
-        android:paddingEnd="8dp"
-        android:paddingTop="8dp"
-        android:paddingBottom="2dp"
+        android:textSize="20sp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="9dp"
+        android:paddingBottom="1dp"
         />
 
     <TextView
@@ -22,11 +22,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="hours"
-        android:textSize="20sp"
-        android:paddingStart="10dp"
-        android:paddingEnd="10dp"
-        android:paddingTop="2dp"
-        android:paddingBottom="12dp"
+        android:textSize="16sp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="1dp"
+        android:paddingBottom="9dp"
         />
 
 </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,4 +10,5 @@
     <color name="primaryDark">#b31b1b</color>
     <color name="openGreen">#388E3C</color>
     <color name="almostOpenGreen">#81C784</color>
+    <color name="closedColor">#757575</color>
 </resources>


### PR DESCRIPTION
- Conform to 16dp padding in dining hall list (http://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-keylines-spacing)
- Make font size slightly smaller: 20sp/16sp, based on Google's typographic scale (http://www.google.com/design/spec/style/typography.html#typography-styles)
- Refresh spinner now uses primary color
- 'Closed' text is now a gray

Don't know if you like all these changes, I can revert ones if you want (or just reject the PR :P)

Haven't played with the new SDK/M Preview yet (apparently it's not too stable, just like the last one). (Also, hotel internet is terrible (but at least it's there).)

![device-2015-05-29-153002](https://cloud.githubusercontent.com/assets/327919/7892140/ffa71ec2-0617-11e5-9428-657a55516a3e.png)
